### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JohnMostlyR/vitest-temporary-fixture/security/code-scanning/1](https://github.com/JohnMostlyR/vitest-temporary-fixture/security/code-scanning/1)

To fix the problem, add a `permissions` block at the top level of the workflow or at the job level, specifying only the minimal permissions required. The safest approach is to add a `permissions` block set to `{ contents: read }` unless there is a job step that needs additional access (such as creating issues or publishing to the repository). Since the provided steps only read code, install dependencies, run checks and tests — all read-only activities — `contents: read` is sufficient. The edit should be made above or directly below the `name` key (line 1) in the `.github/workflows/ci.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
